### PR TITLE
Fix para Conversão entre diferentes EnergyUnits

### DIFF
--- a/physusp/src/com/gedaeusp/domain/EnergyUnit.java
+++ b/physusp/src/com/gedaeusp/domain/EnergyUnit.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 António Miranda, Caio Valente, Igor Topcin, Jorge Melegati, Thales Paiva, Victor Santos
+Copyright 2014 Ant��nio Miranda, Caio Valente, Igor Topcin, Jorge Melegati, Thales Paiva, Victor Santos
 
 This file is part of PhysUSP.
 
@@ -21,12 +21,12 @@ package com.gedaeusp.domain;
 
 public enum EnergyUnit implements Unit
 {
-	Kcal(1.0),
-	KJ(4.184),
-	LO2(5);
-	
+	Kcal(5.0),
+	KJ(20.92),
+	LO2(1.0);
+
 	private double value;
-	
+
 	EnergyUnit(double value){
 		this.setValue(value);
 	}

--- a/physusp/test/com/gedaeusp/domain/UnitValueTest.java
+++ b/physusp/test/com/gedaeusp/domain/UnitValueTest.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 António Miranda, Caio Valente, Igor Topcin, Jorge Melegati, Thales Paiva, Victor Santos
+Copyright 2014 Ant��nio Miranda, Caio Valente, Igor Topcin, Jorge Melegati, Thales Paiva, Victor Santos
 
 This file is part of PhysUSP.
 
@@ -24,27 +24,48 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public class UnitValueTest {
-	@Test	
+	@Test
 	public void convert100KgTo_g()
 	{
 		UnitValue<WeightUnit> weight = new UnitValue<WeightUnit>(100.0, WeightUnit.Kg);
 		double weightIn_g = weight.getValue(WeightUnit.g);
 		assertEquals(100000.0, weightIn_g, 0.000000001);
 	}
-	
-	@Test	
+
+	@Test
 	public void convert100lTo_ml()
 	{
 		UnitValue<VolumeUnit> volume = new UnitValue<VolumeUnit>(100.0, VolumeUnit.l);
 		double volumeIn_ml = volume.getValue(VolumeUnit.ml);
 		assertEquals(100000.0, volumeIn_ml, 0.000000001);
 	}
-	
-	@Test	
+
+	@Test
 	public void convert100mlTo_l()
 	{
 		UnitValue<VolumeUnit> volume = new UnitValue<VolumeUnit>(100.0, VolumeUnit.ml);
 		double volumeIn_l = volume.getValue(VolumeUnit.l);
 		assertEquals(0.1, volumeIn_l, 0.000000001);
+	}
+
+	@Test
+	public void convertLitresO2ToKcal() {
+		UnitValue<EnergyUnit> litresO2 = new UnitValue<EnergyUnit>(100, EnergyUnit.LO2);
+		double kcal = litresO2.getValue(EnergyUnit.Kcal);
+		assertEquals(500, kcal, 0.1);
+	}
+
+	@Test
+	public void convertLitresO2ToKJ() {
+		UnitValue<EnergyUnit> litresO2 = new UnitValue<EnergyUnit>(100, EnergyUnit.LO2);
+		double kcal = litresO2.getValue(EnergyUnit.KJ);
+		assertEquals(2092, kcal, 0.1);
+	}
+
+	@Test
+	public void convertLitresKcalToKJ() {
+		UnitValue<EnergyUnit> litresO2 = new UnitValue<EnergyUnit>(1000, EnergyUnit.Kcal);
+		double kcal = litresO2.getValue(EnergyUnit.KJ);
+		assertEquals(4184, kcal, 0.1);
 	}
 }


### PR DESCRIPTION
As conversões entre unidades de energia estavam erradas.
Modificado o EnergyUnit e adicionados novos testes de unidade.

Para testar, basta realizar um cálculo qualquer, e observar se as conversões estão fazendo sentido na página de resultados:
Kcal = L de O2 \* 5
kJ =  L de O2 \* 20,9
